### PR TITLE
Update info.xml

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -32,12 +32,7 @@ This app then should be installed from the "External Apps" page.
 			<image-tag>1.1.1</image-tag>
 		</docker-install>
 		<scopes>
-			<required>
-			</required>
-			<optional>
-			</optional>
 		</scopes>
-		<protocol>http</protocol>
 		<system>false</system>
 	</external-app>
 </info>


### PR DESCRIPTION
Today new version of AppStore was deployed that ignores "protocol" field, and API scopes are now only "required" no more "optional" or "required" keys in info.xml