### PR TITLE
adjustments for changes in AppAPI in last two months

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,30 +9,22 @@ help:
 	@echo "  Next commands are only for dev environment with nextcloud-docker-dev!"
 	@echo "  They should run from the host you are developing on (with activated venv) and not in the container with Nextcloud!"
 	@echo "  "
-	@echo "  deploy          deploy example to registered 'docker_dev' for Nextcloud"
-	@echo "  "
-	@echo "  run             install Context Chat for Nextcloud"
+	@echo "  run             deploy and install Context Chat for Nextcloud"
 	@echo "  "
 	@echo "  For development of this example use PyCharm run configurations. Development is always set for last Nextcloud."
 	@echo "  First run 'Context Chat' and then 'make manual_register', after that you can use/debug/develop it and easy test."
 	@echo "  "
-	@echo "  register perform registration of running 'Context Chat' into the 'manual_install' deploy daemon."
+	@echo "  register        perform registration of running 'Context Chat' into the 'manual_install' deploy daemon."
 
 #.PHONY: build-push
 #build-push:
 #	docker login ghcr.io
 #	docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/nextcloud/context_chat_backend:2.0.1 --tag ghcr.io/nextcloud/context_chat_backend:latest .
 
-.PHONY: deploy
-deploy:
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister context_chat_backend --silent || true
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:deploy context_chat_backend docker_dev \
-		--info-xml https://raw.githubusercontent.com/nextcloud/context_chat_backend/master/appinfo/info.xml
-
 .PHONY: run
 run:
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister context_chat_backend --silent || true
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register context_chat_backend docker_dev \
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register context_chat_backend \
 		--force-scopes \
 		--info-xml https://raw.githubusercontent.com/nextcloud/context_chat_backend/master/appinfo/info.xml
 
@@ -40,5 +32,5 @@ run:
 register:
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister context_chat_backend --silent || true
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register context_chat_backend manual_install --json-info \
-  "{\"appid\":\"context_chat_backend\",\"name\":\"Context Chat Backend\",\"daemon_config_name\":\"manual_install\",\"version\":\"2.0.1\",\"secret\":\"12345\",\"port\":10034,\"scopes\":[],\"system_app\":0}" \
+  "{\"id\":\"context_chat_backend\",\"name\":\"Context Chat Backend\",\"daemon_config_name\":\"manual_install\",\"version\":\"2.0.1\",\"secret\":\"12345\",\"port\":10034,\"scopes\":[],\"system\":0}" \
   --force-scopes --wait-finish

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Simple Install
 1. Install three mandatory apps for this app to work as desired in your Nextcloud install from the "Apps" page:
-- AppAPI (>= v2.0.3): https://apps.nextcloud.com/apps/app_api
+- AppAPI (>= v2.2.0): https://apps.nextcloud.com/apps/app_api
 - Context Chat (>= 1.1.0): https://apps.nextcloud.com/apps/context_chat
 - Assistant: https://apps.nextcloud.com/apps/assistant (The OCS API or the `occ` commands can also be used to interact with this app but it recommended to do that through a Text Processing OCP API consumer like the Assitant app.)
 2. Install this backend app (Context Chat Backend: https://apps.nextcloud.com/apps/context_chat_backend) from the "External Apps" page

--- a/example.env
+++ b/example.env
@@ -10,7 +10,7 @@
 #TRANSFORMERS_OFFLINE=1
 
 # AppAPI headers
-AA_VERSION=2.0.3
+AA_VERSION=2.2.0
 APP_SECRET=12345
 APP_ID=context_chat_backend
 APP_DISPLAY_NAME=Context Chat Backend

--- a/example.env
+++ b/example.env
@@ -15,11 +15,9 @@ APP_SECRET=12345
 APP_ID=context_chat_backend
 APP_DISPLAY_NAME=Context Chat Backend
 APP_VERSION=2.0.1
-APP_PROTOCOL=http
 APP_HOST=0.0.0.0
 APP_PORT=10034
 APP_PERSISTENT_STORAGE=persistent_storage
-IS_SYSTEM_APP=0
 NEXTCLOUD_URL=http://nextcloud.local
 
 # CUDA Support


### PR DESCRIPTION
1. `deploy` command was deprecated in AppAPI `2.1.0`
2. for dev registration AppAPI now accepts values in `--json-info` with the same key names as in `info.xml`:
    * `appid` -> `id`
    * `system_app` -> `system`
3. `occ app_api:app:register`  will take default deploy daemon if not specify, it is more easy for people than direct specify name

Changes `1` and `2` are not mandotory till one-two months more, after that we plan to drop old values.