### PR TITLE
Fix: Sources that are decoded as only spaces fail to index

### DIFF
--- a/context_chat_backend/chain/ingest/injest.py
+++ b/context_chat_backend/chain/ingest/injest.py
@@ -59,7 +59,7 @@ def _sources_to_indocuments(config: TConfig, sources: list[UploadFile]) -> list[
 		# transform the source to have text data
 		content = decode_source(source)
 
-		if content is None or content.strip() == '':
+		if content is None or (content := content.strip()) == '':
 			logger.debug('decoded empty source', extra={ 'source_id': source.filename })
 			continue
 

--- a/context_chat_backend/chain/ingest/injest.py
+++ b/context_chat_backend/chain/ingest/injest.py
@@ -59,7 +59,7 @@ def _sources_to_indocuments(config: TConfig, sources: list[UploadFile]) -> list[
 		# transform the source to have text data
 		content = decode_source(source)
 
-		if content is None or content == '':
+		if content is None or content.strip() == '':
 			logger.debug('decoded empty source', extra={ 'source_id': source.filename })
 			continue
 


### PR DESCRIPTION
I noticed that some of the documents that fail to get indexed were because they get decoded as a lot of empty characters which the embedding model fails to embed. This just changes the check for an empty document to strip whitespace characters during the check. I wrote a quick fix that worked on my instance and caused the error to disappear.
<details >
<summary>Log</summary>

```
{"timestamp": "2025-02-12T05:28:01.914420+00:00", "level": "INFO", "logger": "ccb.nextwork_em", "message": "Sending embedding request for 0 chunks of the following sizes (total: 0):", "filename": "network_em.py", "function": "_get_embedding", "line": 43, "thread_name": "AnyIO worker thread", "pid": 204, "lengths": []}
{"timestamp": "2025-02-12T05:28:02.006809+00:00", "level": "ERROR", "logger": "ccb.vectordb", "message": "Error adding documents to vectordb", "filename": "pgvector.py", "function": "add_indocuments", "line": 156, "thread_name": "AnyIO worker thread", "pid": 204, "exc_info": "Traceback (most recent call last):\n  File \"/app/context_chat_backend/network_em.py\", line 59, in _get_embedding\n    response.raise_for_status()\n  File \"/usr/local/lib/python3.11/dist-packages/httpx/_models.py\", line 829, in raise_for_status\n    raise HTTPStatusError(message, request=request, response=self)\nhttpx.HTTPStatusError: Server error '500 Internal Server Error' for url 'http://localhost:5000/v1/embeddings'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/app/context_chat_backend/vectordb/pgvector.py\", line 137, in add_indocuments\n    chunk_ids = self.client.add_documents(indoc.documents)\n                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.11/dist-packages/langchain_core/vectorstores/base.py\", line 286, in add_documents\n    return self.add_texts(texts, metadatas, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.11/dist-packages/langchain_postgres/vectorstores.py\", line 885, in add_texts\n    embeddings = self.embedding_function.embed_documents(texts_)\n                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/context_chat_backend/network_em.py\", line 72, in embed_documents\n    return self._get_embedding(texts)  # pyright: ignore[reportReturnType]\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/context_chat_backend/network_em.py\", line 61, in _get_embedding\n    raise EmbeddingException(f'Error: failed to get embeddings: {response.text}') from e\ncontext_chat_backend.types.EmbeddingException: Error: failed to get embeddings: {\"error\":{\"message\":\"llama_decode returned -1\",\"type\":\"internal_server_error\",\"param\":null,\"code\":null}}", "source_id": "files__default: 15990"}
```
</details>