### PR TITLE
feat: add env var to skip model downloads from huggingface

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -53,6 +53,11 @@ HaRP is not supported in this app yet, please use Docker Socket Proxy (DSP) as t
 				<display-name>PostgreSQL URI</display-name>
 				<description>A URI in the form of "postgresql+psycopg://pguser:pgpass@localhost:5432/nextcloud" that supports the pgvector extension. If this is set, no separate internal database will be setup for vector storage. This should be accessible by the ex-app container nc_app_context_chat_backend.</description>
 			</variable>
+			<variable>
+				<name>CC_DOWNLOAD_MODELS_FROM_HF</name>
+				<display-name>Auto-download models from Huggingface</display-name>
+				<description>When set to "false", "0" or "no", initial download of the Huggingface models will be skipped in the init phase. They would have to be downloaded and placed in the persistent storage manually or through a mount point.</description>
+			</variable>
 		</environment-variables>
 	</external-app>
 </info>

--- a/context_chat_backend/controller.py
+++ b/context_chat_backend/controller.py
@@ -53,6 +53,7 @@ setup_env_vars()
 repair_run()
 ensure_config_file()
 logger = logging.getLogger('ccb.controller')
+__download_models_from_hf = os.environ.get('CC_DOWNLOAD_MODELS_FROM_HF', 'true').lower() in ('1', 'true', 'yes')
 
 models_to_fetch = {
 	# embedding model
@@ -65,7 +66,7 @@ models_to_fetch = {
 		'allow_patterns': ['config.json', 'merges.txt', 'tokenizer.json', 'tokenizer_config.json', 'vocab.json'],
 		'revision': '607a30d783dfa663caf39e06633721c8d4cfcd7e',
 	}
-}
+} if __download_models_from_hf else {}
 app_enabled = Event()
 
 def enabled_handler(enabled: bool, _: NextcloudApp | AsyncNextcloudApp) -> str:

--- a/example.env
+++ b/example.env
@@ -27,3 +27,6 @@ NEXTCLOUD_URL=http://nextcloud.local
 # CUDA Support
 NVIDIA_VISIBLE_DEVICES=all
 NVIDIA_DRIVER_CAPABILITIES=compute
+
+# Set to "false", "0" or "no" to disable automatic model downloading from Huggingface in the init phase
+CC_DOWNLOAD_MODELS_FROM_HF=true


### PR DESCRIPTION
This option allows setup of CCB without any need to contact huggingface or even offline. The model files listed [here](https://github.com/nextcloud/context_chat_backend/blob/7aa3216da2ec33b27e93a1c9c4214d34a123ab13/context_chat_backend/controller.py#L59-L70) should be downloaded and placed manually in the persistent storage "/nc_app_context_chat_backend_data/model_files".