### PR TITLE
fix(pgvector): add chunking to prevent long list of args in queries

### DIFF
--- a/context_chat_backend/vectordb/pgvector.py
+++ b/context_chat_backend/vectordb/pgvector.py
@@ -271,20 +271,22 @@ class VectorDB(BaseVectorDB):
 				.filter(AccessListStore.source_id == source_id)
 			)
 			session.execute(stmt)
-			session.commit()
 
-			stmt = (
-				postgresql_dialects.insert(AccessListStore)
-				.values([
-					{
-						'uid': user_id,
-						'source_id': source_id,
-					}
-					for user_id in user_ids
-				])
-				.on_conflict_do_nothing(index_elements=['uid', 'source_id'])
-			)
-			session.execute(stmt)
+			for i in range(0, len(user_ids), PG_BATCH_SIZE):
+				batched_uids = user_ids[i:i+PG_BATCH_SIZE]
+				stmt = (
+					postgresql_dialects.insert(AccessListStore)
+					.values([
+						{
+							'uid': user_id,
+							'source_id': source_id,
+						}
+						for user_id in batched_uids
+					])
+					.on_conflict_do_nothing(index_elements=['uid', 'source_id'])
+				)
+				session.execute(stmt)
+
 			session.commit()
 		except SafeDbException as e:
 			session.rollback()
@@ -324,27 +326,31 @@ class VectorDB(BaseVectorDB):
 
 			match op:
 				case UpdateAccessOp.allow:
-					stmt = (
-						postgresql_dialects.insert(AccessListStore)
-						.values([
-							{
-								'uid': user_id,
-								'source_id': source_id,
-							}
-							for user_id in user_ids
-						])
-						.on_conflict_do_nothing(index_elements=['uid', 'source_id'])
-					)
-					session.execute(stmt)
+					for i in range(0, len(user_ids), PG_BATCH_SIZE):
+						batched_uids = user_ids[i:i+PG_BATCH_SIZE]
+						stmt = (
+							postgresql_dialects.insert(AccessListStore)
+							.values([
+								{
+									'uid': user_id,
+									'source_id': source_id,
+								}
+								for user_id in batched_uids
+							])
+							.on_conflict_do_nothing(index_elements=['uid', 'source_id'])
+						)
+						session.execute(stmt)
 					session.commit()
 
 				case UpdateAccessOp.deny:
-					stmt = (
-						sa.delete(AccessListStore)
-						.filter(AccessListStore.uid.in_(user_ids))
-						.filter(AccessListStore.source_id == source_id)
-					)
-					session.execute(stmt)
+					for i in range(0, len(user_ids), PG_BATCH_SIZE):
+						batched_uids = user_ids[i:i+PG_BATCH_SIZE]
+						stmt = (
+							sa.delete(AccessListStore)
+							.filter(AccessListStore.uid.in_(batched_uids))
+							.filter(AccessListStore.source_id == source_id)
+						)
+						session.execute(stmt)
 					session.commit()
 
 					# check if all entries related to the source were deleted
@@ -356,6 +362,8 @@ class VectorDB(BaseVectorDB):
 			logger.info('Error: updating access list', exc_info=e, extra={
 				'source_id': source_id,
 			})
+		except DbException:
+			raise
 		except Exception as e:
 			session.rollback()
 			raise DbException('Error: updating access list') from e
@@ -388,33 +396,35 @@ class VectorDB(BaseVectorDB):
 		if len(source_ids) == 0:
 			return
 
-		filter_ = [
-			AccessListStore.source_id.in_(source_ids) if len(source_ids) > 1
-			else AccessListStore.source_id == source_ids[0]
-		]
-
 		session = session_ or self.session_maker()
 
 		try:
-			stmt = (
-				sa.select(AccessListStore.source_id)
-				.filter(*filter_)
-				.distinct()
-			)
-			result = session.execute(stmt).fetchall()
+			# find orphaned source_ids (no AccessListStore entry) in batches
+			orphaned_ids = []
+			for i in range(0, len(source_ids), PG_BATCH_SIZE):
+				batched_ids = source_ids[i:i+PG_BATCH_SIZE]
+				stmt = (
+					sa.select(DocumentsStore.source_id)
+					.filter(DocumentsStore.source_id.in_(batched_ids))
+					.filter(
+						~sa.exists(  # NOT EXISTS
+							sa.select(sa.literal(1))
+							.where(AccessListStore.source_id == DocumentsStore.source_id)
+						)
+					)
+				)
+				result = session.execute(stmt).fetchall()
+				orphaned_ids.extend(str(r.source_id) for r in result)
+
+			if len(orphaned_ids) > 0:
+				self.delete_source_ids(orphaned_ids, session)
+		except DbException:
+			raise
 		except Exception as e:
+			raise DbException('Error: cleaning up orphaned source ids') from e
+		finally:
 			if session_ is None:
 				session.close()
-			raise DbException('Error: getting source ids from access list') from e
-
-		existing_links = [str(r.source_id) for r in result]
-		to_delete = [source_id for source_id in source_ids if source_id not in existing_links]
-
-		if len(to_delete) > 0:
-			self.delete_source_ids(to_delete, session_)
-
-		if session_ is None:
-			session.close()
 
 	def delete_source_ids(self, source_ids: list[str], session_: orm.Session | None = None):
 		session = session_ or self.session_maker()
@@ -423,35 +433,32 @@ class VectorDB(BaseVectorDB):
 			collection = self.client.get_collection(session)
 
 			# entry from "AccessListStore" is deleted automatically due to the foreign key constraint
-			stmt_doc = (
-				sa.delete(DocumentsStore)
-				.filter(DocumentsStore.source_id.in_(source_ids))
-				.returning(DocumentsStore.chunks)
-			)
+      # batch the deletion to avoid hitting the query parameter limit
+			chunks_to_delete = []
+			for i in range(0, len(source_ids), PG_BATCH_SIZE):
+				batched_ids = source_ids[i:i+PG_BATCH_SIZE]
+				stmt_doc = (
+					sa.delete(DocumentsStore)
+					.filter(DocumentsStore.source_id.in_(batched_ids))
+					.returning(DocumentsStore.chunks)
+				)
+				doc_result = session.execute(stmt_doc)
+				chunks_to_delete.extend(str(c) for res in doc_result for c in res.chunks)
 
-			doc_result = session.execute(stmt_doc)
-			chunks_to_delete = [str(c) for res in doc_result for c in res.chunks]
-		except Exception as e:
-			session.rollback()
-			if session_ is None:
-				session.close()
-			raise DbException('Error: deleting source ids from docs store') from e
+			for i in range(0, len(chunks_to_delete), PG_BATCH_SIZE):
+				batched_chunks = chunks_to_delete[i:i+PG_BATCH_SIZE]
+				stmt_chunks = (
+					sa.delete(self.client.EmbeddingStore)
+					.filter(self.client.EmbeddingStore.collection_id == collection.uuid)
+					.filter(self.client.EmbeddingStore.id.in_(batched_chunks))
+				)
+				session.execute(stmt_chunks)
 
-		try:
-			stmt_chunks = (
-				sa.delete(self.client.EmbeddingStore)
-				.filter(self.client.EmbeddingStore.collection_id == collection.uuid)
-				.filter(self.client.EmbeddingStore.id.in_(chunks_to_delete))
-			)
-
-			session.execute(stmt_chunks)
 			session.commit()
 		except Exception as e:
-			logger.error('Error deleting chunks, rolling back documents store deletion for source ids')
+			logger.error('Error deleting source ids, rolling back changes.')
 			session.rollback()
-			raise DbException(
-				'Error: deleting chunks, rolling back documents store deletion for source ids'
-			) from e
+			raise DbException('Error: deleting source ids, rolling back changes.') from e
 		finally:
 			if session_ is None:
 				session.close()
@@ -469,23 +476,20 @@ class VectorDB(BaseVectorDB):
 
 				doc_result = session.execute(stmt)
 				chunks_to_delete = [str(c) for res in doc_result for c in res.chunks]
-			except Exception as e:
-				session.rollback()
-				raise DbException('Error: deleting provider from docs store') from e
 
-			try:
-				stmt = (
-					sa.delete(self.client.EmbeddingStore)
-					.filter(self.client.EmbeddingStore.collection_id == collection.uuid)
-					.filter(self.client.EmbeddingStore.id.in_(chunks_to_delete))
-				)
-				session.execute(stmt)
+				for i in range(0, len(chunks_to_delete), PG_BATCH_SIZE):
+					batched_chunks = chunks_to_delete[i:i+PG_BATCH_SIZE]
+					stmt = (
+						sa.delete(self.client.EmbeddingStore)
+						.filter(self.client.EmbeddingStore.collection_id == collection.uuid)
+						.filter(self.client.EmbeddingStore.id.in_(batched_chunks))
+					)
+					session.execute(stmt)
+
 				session.commit()
 			except Exception as e:
 				session.rollback()
-				raise DbException(
-					'Error: deleting chunks, rolling back documents store deletion for provider'
-				) from e
+				raise DbException('Error: deleting chunks, rolling back changes') from e
 
 	def delete_user(self, user_id: str):
 		with self.session_maker() as session:


### PR DESCRIPTION

The error log for the non-chunked deletion query:
```
{"timestamp": "2026-03-20T11:45:29.417326+00:00", "level": "ERROR", "logger": "ccb.vectordb", "message": "Error deleting chunks, rolling back documents store deletion for source ids", "filename": "pgvector.py", "function": "delete_source_ids", "line": 438, "thread_name": "AnyIO worker thread", "pid": 2148, "version": "5.3.0", "exc_info": "Traceback (most recent call last):\n  File \"/usr/local/lib/python3.11/dist-packages/sqlalchemy/engine/base.py\", line 1967, in _exec_single_context\n    self.dialect.do_execute(\n  File \"/usr/local/lib/python3.11/dist-packages/sqlalchemy/engine/default.py\", line 952, in do_execute\n    cursor.execute(statement, parameters)\n  File \"/usr/local/lib/python3.11/dist-packages/psycopg/cursor.py\", line 117, in execute\n    raise ex.with_traceback(None)\npsycopg.OperationalError: sending query and params failed: number of parameters must be between 0 and 65535\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/app/context_chat_backend/vectordb/pgvector.py\", line 435, in delete_source_ids\n    session.execute(stmt_chunks)\n  File \"/usr/local/lib/python3.11/dist-packages/sqlalchemy/orm/session.py\", line 2351, in execute\n    return self._execute_internal(\n           ^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.11/dist-packages/sqlalchemy/orm/session.py\", line 2249, in _execute_internal\n    result: Result[Any] = compile_state_cls.orm_execute_statement(\n                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.11/dist-packages/sqlalchemy/orm/bulk_persistence.py\", line 2033, in orm_execute_statement\n    return super().orm_execute_statement(\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.11/dist-packages/sqlalchemy/orm/context.py\", line 306, in orm_execute_statement\n    result = conn.execute(\n             ^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.11/dist-packages/sqlalchemy/engine/base.py\", line 1419, in execute\n    return meth(\n           ^^^^^\n  File \"/usr/local/lib/python3.11/dist-packages/sqlalchemy/sql/elements.py\", line 527, in _execute_on_connection\n    return connection._execute_clauseelement(\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.11/dist-packages/sqlalchemy/engine/base.py\", line 1641, in _execute_clauseelement\n    ret = self._execute_context(\n          ^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.11/dist-packages/sqlalchemy/engine/base.py\", line 1846, in _execute_context\n    return self._exec_single_context(\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.11/dist-packages/sqlalchemy/engine/base.py\", line 1986, in _exec_single_context\n    self._handle_dbapi_exception(\n  File \"/usr/local/lib/python3.11/dist-packages/sqlalchemy/engine/base.py\", line 2363, in _handle_dbapi_exception\n    raise sqlalchemy_exception.with_traceback(exc_info[2]) from e\n  File \"/usr/local/lib/python3.11/dist-packages/sqlalchemy/engine/base.py\", line 1967, in _exec_single_context\n    self.dialect.do_execute(\n  File \"/usr/local/lib/python3.11/dist-packages/sqlalchemy/engine/default.py\", line 952, in do_execute\n    cursor.execute(statement, parameters)\n  File \"/usr/local/lib/python3.11/dist-packages/psycopg/cursor.py\", line 117, in execute\n    raise ex.with_traceback(None)\nsqlalchemy.exc.OperationalError: (psycopg.OperationalError) sending query and params failed: number of parameters must be between 0 and 65535\n[SQL: DELETE FROM langchain_pg_embedding WHERE langchain_pg_embedding.collection_id = %(collection_id_1)s::UUID AND langchain_pg_embedding.id IN (%(id_1_1)s::VARCHAR, %(id_1_2)s::VARCHAR, %(id_1_3)s::VARCHAR, %(id_1_4)s::VARCHAR, %(id_1_5)s::VARCHAR, %(id_1_6)s::VARCHAR, %(id_1_7)s::VARCHAR, %(id_1_8)s::VARCHAR, %(id_1_9)s::VARCHAR, %(id_1_10)s::VARCHAR, %(id_1_11)s::VARCHAR, %(id_1_12)s::VARCHAR, %(id_1_13)s::VARCHAR, %(id_1_14)s::VARCHAR, ...
```
```
raise ex.with_traceback(None)\nsqlalchemy.exc.OperationalError: (psycopg.OperationalError) sending query and params failed: number of parameters must be between 0 and 65535
```