### PR TITLE
fix(info): use canonical regex form for downloadLogs route URL

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -39,7 +39,7 @@ Setup background job workers as described here: https://docs.nextcloud.com/serve
 		</docker-install>
 		<routes>
 			<route>
-				<url>downloadLogs</url>
+				<url>^/downloadLogs$</url>
 				<verb>GET</verb>
 				<access_level>ADMIN</access_level>
 				<headers_to_exclude>[]</headers_to_exclude>


### PR DESCRIPTION
Changes are not urgent, fell free to merge them in a month when everyone will update AppAPI on their isntances.

AppAPI from next version(this will be backported to all versions) now marks the way that we have write such urls as deprecated and will emit debug log warning for them:

https://github.com/nextcloud/app_api/pull/874


P.S: I have tested this, but please, check this again on an non-update and updated version of AppAPI before merge.