### PR TITLE
fix: drop latin-1 decode in source title and userIds

### DIFF
--- a/context_chat_backend/chain/ingest/injest.py
+++ b/context_chat_backend/chain/ingest/injest.py
@@ -257,7 +257,7 @@ def _sources_to_indocuments(
 
 		metadata = {
 			'source': source.reference,
-			'title': _decode_latin_1(source.title),
+			'title': source.title,
 			'type': source.type,
 		}
 		doc = Document(page_content=content, metadata=metadata)
@@ -271,7 +271,7 @@ def _sources_to_indocuments(
 
 		indocuments[db_id] = InDocument(
 			documents=split_docs,
-			userIds=list(map(_decode_latin_1, source.userIds)),
+			userIds=source.userIds,
 			source_id=source.reference,
 			provider=source.provider,
 			modified=source.modified,  # pyright: ignore[reportArgumentType]
@@ -299,7 +299,7 @@ def _increase_access_for_existing_sources(
 		try:
 			vectordb.update_access(
 				UpdateAccessOp.ALLOW,
-				list(map(_decode_latin_1, source.userIds)),
+				source.userIds,
 				source.reference,
 			)
 			results[db_id] = None
@@ -390,14 +390,6 @@ def _process_sources(
 	return source_proc_results
 
 
-def _decode_latin_1(s: str) -> str:
-	try:
-		return s.encode('latin-1').decode('utf-8')
-	except UnicodeDecodeError:
-		logger.error('Failed to decode latin-1: %s', s)
-		return s
-
-
 def embed_sources(
 	vectordb_loader: VectorDBLoader,
 	config: TConfig,
@@ -405,7 +397,7 @@ def embed_sources(
 ) -> Mapping[int, IndexingError | None]:
 	logger.debug('Embedding sources:', extra={
 		'source_ids': [
-			f'{source.reference} ({_decode_latin_1(source.title)})'
+			f'{source.reference} ({source.title})'
 			for source in sources.values()
 		],
 		'len(source_ids)': len(sources),


### PR DESCRIPTION
fixing this issue:

```
2026-05-28T07:53:19+0000: [ERROR|utils]: original traceback of embed_sources (PID 22239, exitcode: 0): Traceback (most recent call last):
  File "/app/context_chat_backend/utils.py", line 138, in exception_wrap
    value = None if fun is None else fun(*args, **kwargs)
                                     ^^^^^^^^^^^^^^^^^^^^
  File "/app/context_chat_backend/chain/ingest/injest.py", line 407, in embed_sources
    'source_ids': [
                  ^
  File "/app/context_chat_backend/chain/ingest/injest.py", line 408, in <listcomp>
    f'{source.reference} ({_decode_latin_1(source.title)})'
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/context_chat_backend/chain/ingest/injest.py", line 395, in _decode_latin_1
    return s.encode('latin-1').decode('utf-8')
           ^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'latin-1' codec can't encode character '\u2013' in position 27: ordinal not in range(256)
```