### PR TITLE
feat: rotate the internal PostgreSQL logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ volumes:
 Logs are stored in the `logs/` directory in the persistent directory. In a docker container, it should be at `/nc_app_context_chat_backend/logs/`. The log file is named `ccb.log` and is set to otate at 20 MB with 10 backups. These logs are in JSONL format, i.e. each line is a valid JSON object.
 Now only warning and above logs are printed to the console. All the debug logs are written to the log file if `debug` is set to `true` in the config file.
 The logs of the embedding server are written to `logs/embedding_server_[date].log` in the persistent directory, it rotates with date change and is not in JSONL format, just raw stdout and stderr from the embedding server's process.
+The internal vector database (PostgreSQL) writes its logs to `vector_db_data/pgsql/log/` in the persistent directory, one file per weekday (e.g. `postgresql-Mon.log`); each is overwritten when that weekday comes round again, so the logs are kept for about a week.
 
 ## Configuration
 Configuration resides inside the persistent storage as `config.yaml`. The location is `$APP_PERSISTENT_STORAGE`. By default it would be at `/nc_app_context_chat_backend_data/config.yaml` inside the container.

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - add gh workflows for docker builds and do separate cpu, cuda and rocm (vulkan) images (#295) @kyteinsky
 
 ### Changed
+- rotate the internal PostgreSQL logs into one file per weekday instead of a single ever-growing logfile (#312) @sanzakicesarr
 - update readme according to the latest changes (#300) @kyteinsky
 - bump llama_cpp_python to 0.3.23 (#301) @kyteinsky
 

--- a/dockerfile_scripts/pgsql/setup.sh
+++ b/dockerfile_scripts/pgsql/setup.sh
@@ -11,7 +11,7 @@ source "$(dirname $(realpath $0))/env"
 
 if [ x"$1" == "xstop" ]; then
     echo -n Stopping PostgreSQL...
-    sudo -u postgres ${PG_BIN}/pg_ctl -D "$DATA_DIR" -l "${DATA_DIR}/logfile" -o "-p ${PG_PORT}" stop
+    sudo -u postgres ${PG_BIN}/pg_ctl -D "$DATA_DIR" -o "-p ${PG_PORT}" stop
     exit 0
 fi
 
@@ -47,8 +47,19 @@ if [ ! -d "$DATA_DIR/base" ]; then
     sudo -u postgres ${PG_BIN}/initdb -D "$DATA_DIR" -E UTF8
 fi
 
+# Rotate the internal PostgreSQL logs with the built-in logging collector: one
+# file per weekday (postgresql-Mon.log ... postgresql-Sun.log) under
+# "$DATA_DIR/log". The collector overwrites a weekday file only on time-based
+# rotation, not on startup, so a frequently-restarted container would otherwise
+# append to last week's same-named file. Before starting, drop the pre-rotation
+# single logfile and any weekday log at least six days old (find -mtime +5), so
+# last week's file is always gone before its name is reused. See #303.
+rm -f "${DATA_DIR}/logfile"
+find "${DATA_DIR}/log" -maxdepth 1 -type f -name 'postgresql-*.log' -mtime +5 -delete 2>/dev/null || true
+PG_LOG_OPTS="-c logging_collector=on -c log_directory=log -c log_filename=postgresql-%a.log -c log_rotation_age=1d -c log_rotation_size=0 -c log_truncate_on_rotation=on"
+
 echo "Starting PostgreSQL..."
-sudo -u postgres ${PG_BIN}/pg_ctl -D "$DATA_DIR" -l "${DATA_DIR}/logfile" -o "-p ${PG_PORT}" start
+sudo -u postgres ${PG_BIN}/pg_ctl -D "$DATA_DIR" -o "-p ${PG_PORT} ${PG_LOG_OPTS}" start
 
 echo "Waiting for PostgreSQL to start..."
 until sudo -u postgres ${PG_SQL} -c "SELECT 1" > /dev/null 2>&1; do


### PR DESCRIPTION
## What & why

Fixes #303.

The internal vector-db PostgreSQL was started with `pg_ctl -l "$DATA_DIR/logfile"`, redirecting all output to a single file that grows without bound and is never rotated — the `logfile` the issue points at.

This enables PostgreSQL's built-in logging collector with the rotation scheme from the PostgreSQL manual's own example, and drops the `-l` redirect so the collector is the only log sink:

| option | effect |
| --- | --- |
| `logging_collector=on` | PostgreSQL manages its own log files (required for rotation) |
| `log_directory=log` | logs live in `$DATA_DIR/log/` (PostgreSQL's default location, inside the persistent volume) |
| `log_filename=postgresql-%a.log` | one file per weekday → `postgresql-Mon.log` … `postgresql-Sun.log` |
| `log_rotation_age=1d` + `log_truncate_on_rotation=on` | a long-running server overwrites each weekday file when its day comes round again |
| `log_rotation_size=0` | size-based rotation off (see note below) |

## Bounding across restarts

`log_truncate_on_rotation` only fires on **time-based** rotation while the server runs across a day boundary — **not on startup**. Since this ExApp restarts the internal PostgreSQL on every app restart/update, the weekday files would otherwise be *appended to* week after week and keep growing (verified empirically: a restart doubles the file).

So before starting the server, `setup.sh` removes the legacy single `logfile` and any weekday log more than five days old (so last week's file is always gone before its weekday name is reused):

```sh
rm -f "${DATA_DIR}/logfile"
find "${DATA_DIR}/log" -maxdepth 1 -type f -name 'postgresql-*.log' -mtime +5 -delete 2>/dev/null || true
```

This keeps the logs bounded to about a week no matter how often the container restarts, and reclaims the old unbounded `logfile` on upgraded installs. Same-day restarts keep appending to the current day's file, so no log lines are lost.

## Notes for review

- The brief pre-collector startup lines now go to the container's stdout (visible in `docker logs`), consistent with how the rest of the stack already logs via supervisord.
- The settings are passed on the `pg_ctl` command line, so existing data dirs get rotation on their next restart without touching `postgresql.conf`.
- `log_rotation_size=0` is intentional: with `%a` filenames PostgreSQL reopens the *same* file on a size-based rotation **without** truncating it (verified empirically — a 10 kB cap still let the file grow to ~220 kB), so a size cap cannot bound a day's file. Time-based daily rotation plus the startup cleanup is what bounds the logs.
- The README `## Logs` section now documents where the internal PostgreSQL logs live and their ~1-week retention.

## Tested

In a stock `postgres:16` container: the server starts, no `logfile` is created, `logging_collector` is on, `$DATA_DIR/log/postgresql-<weekday>.log` is created and receives output; a restart appends to the same-day file; and the startup cleanup removes the legacy `logfile`, deletes a weekday log older than five days, and preserves both the current day's file and a five-day-old file.