### PR TITLE
fix: forkserver child processes' logs never reach ccb.log (#319)

### DIFF
--- a/context_chat_backend/utils.py
+++ b/context_chat_backend/utils.py
@@ -25,6 +25,42 @@ T = TypeVar('T')
 _logger = logging.getLogger('ccb.utils')
 _MAX_STD_CAPTURE_CHARS = 64 * 1024
 
+# forkserver children re-import without __main__, so setup_logging() (guarded by
+# `if __name__ == "__main__"` in main.py) never runs in them and child loggers lose their
+# handlers (upstream #319). Relay child `ccb.*` records to the parent's real handlers via a single
+# QueueListener (one writer -> no rotation race); a QueueHandler is installed per child below.
+import logging.handlers  # noqa: E402
+
+_log_queue = None
+_log_listener = None
+
+
+def _ensure_log_listener():
+	"""Lazily start a QueueListener bound to the parent's real `ccb` handlers. Returns the queue
+	(or None if setup_logging hasn't configured any handlers yet)."""
+	global _log_queue, _log_listener
+	if _log_listener is not None:
+		return _log_queue
+	ccb_logger = logging.getLogger('ccb')
+	handlers = list(ccb_logger.handlers) or list(logging.getLogger().handlers)
+	if not handlers:
+		return None
+	_log_queue = mp.Queue()
+	_log_listener = logging.handlers.QueueListener(_log_queue, *handlers, respect_handler_level=True)
+	_log_listener.start()
+	return _log_queue
+
+
+def _setup_child_logging(queue):
+	"""Install a QueueHandler on the child's `ccb` logger so its records reach the parent listener."""
+	if queue is None:
+		return
+	qh = logging.handlers.QueueHandler(queue)
+	ccb = logging.getLogger('ccb')
+	ccb.handlers = [qh]
+	ccb.setLevel(logging.DEBUG)
+	ccb.propagate = False
+
 
 def not_none(value: T | None) -> TypeGuard[T]:
 	return value is not None
@@ -112,12 +148,14 @@ def _truncate_capture(text: str) -> str:
 	)
 
 
-def exception_wrap(fun: Callable | None, *args, resconn: Connection, stdconn: Connection, **kwargs):
+def exception_wrap(fun: Callable | None, *args, resconn: Connection, stdconn: Connection, _log_queue=None, **kwargs):
 	# ignore SIGINT and SIGTERM in child processes these signals don't immediately stop these processes
 	# the handling is done in the fastapi lifetime to do a graceful shutdown
 	# SIGKILL is not ignored
 	signal.signal(signal.SIGINT, signal.SIG_IGN)
 	signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
+	_setup_child_logging(_log_queue)
 
 	# Preserve real stderr FD for faulthandler before we redirect sys.stderr.
 	_faulthandler_fd = os.dup(2)
@@ -174,6 +212,7 @@ def exec_in_proc(group=None, target=None, name=None, args=(), kwargs=None, *, da
 	std_pconn, std_cconn = mp.Pipe()
 	kwargs['resconn'] = cconn
 	kwargs['stdconn'] = std_cconn
+	kwargs['_log_queue'] = _ensure_log_listener()
 	p = mp.Process(
 		group=group,
 		target=partial(exception_wrap, target),


### PR DESCRIPTION
Follow-up to #319. `setup_logging()` runs in `main.py` under `if __name__ == '__main__'`, and the forkserver start method is set right after it, so the forkserver children re-import the package without going through `__main__` and never run the logging setup — their `ccb.*` loggers end up with no handlers. The `stdconn` pipe in `exception_wrap` relays the child's raw stdout/stderr (and the faulthandler dump on a crash), but not logging records, so the per-request embed/ingest logs from the child processes get silently dropped. On our instance `ccb.log` only ever showed the main pid.

This does what you were happy with in the issue: one `multiprocessing.Queue` plus a `QueueListener` in the parent bound to the real `ccb` handlers (single writer, so no `RotatingFileHandler` rotation race), and a `QueueHandler` installed on the child's `ccb` logger from inside `exception_wrap`. The queue is passed in as a kwarg from `exec_in_proc`, and it's scoped to `ccb.*` so it doesn't start relaying unrelated library logs.

Running this on our 5.4.0 instance now — the child records (`ccb.injest`, `ccb.vectordb`, `ccb.nextwork_em`, …) show up in `ccb.log` with the child pid, where before we only saw the main pid.

<details><summary>ccb.log with the patch (pid 44 is the main worker, the rest are forkserver children)</summary>

```
{"timestamp": "05:58:08.485", "level": "INFO", "logger": "ccb.task_fetcher", "message": "embed_sources finished for 4 source(s): 4 succeeded, 0 errored", "pid": 44}
{"timestamp": "05:58:07.716", "level": "DEBUG", "logger": "ccb.injest", "message": "db filter source results", "pid": 435237}
{"timestamp": "05:58:07.711", "level": "DEBUG", "logger": "ccb.vectordb", "message": "Embedding source mail__mail: 3105:8273303: 7 chunk(s) in 1 batch(es)", "pid": 435230}
{"timestamp": "05:58:07.711", "level": "INFO", "logger": "ccb.nextwork_em", "message": "Sending embedding request for 7 chunks of the following sizes (total: 12271):", "pid": 435230}
```
</details>

Developed with AI assistance and verified on a live 5.4.0 deployment.
