### PR TITLE
fix: send queries to E5 embedding models in instruct format

### DIFF
--- a/context_chat_backend/network_em.py
+++ b/context_chat_backend/network_em.py
@@ -23,6 +23,9 @@ from .types import (
 
 logger = logging.getLogger('ccb.nextwork_em')
 TCP_CONNECT_TIMEOUT = 2.0  # seconds
+# instruct task for e5 models (https://huggingface.co/intfloat/multilingual-e5-large-instruct),
+# including the bundled default model multilingual-e5-large-instruct
+E5_QUERY_INSTRUCT = 'Given a web search query, retrieve relevant passages that answer the query'
 
 # Copied from llama_cpp/llama_types.py
 
@@ -176,4 +179,5 @@ class NetworkEmbeddings(Embeddings):
 		return results
 
 	def embed_query(self, text: str) -> list[float]:
-		return self._get_embedding(text)  # pyright: ignore[reportReturnType]
+		# e5 models expect queries in the "Instruct: ...\nQuery: ..." format; documents are embedded raw
+		return self._get_embedding(f'Instruct: {E5_QUERY_INSTRUCT}\nQuery: {text}')  # pyright: ignore[reportReturnType]


### PR DESCRIPTION
## Problem

The default bundled embedding model is [multilingual-e5-large-instruct](https://huggingface.co/intfloat/multilingual-e5-large-instruct). Per its model card, E5-instruct queries must be formatted as:

```
Instruct: <task description>
Query: <query>
```

Otherwise retrieval quality degrades badly — in particular, cross-language search (e.g. a German query against English documents) fails almost completely. The reporter of #331 reproduced this: documents were embedded raw (which is correct for E5), but queries were also sent raw, without the instruct prefix.

## Change

Wrap only the query in `embed_query` with the standard E5 instruct task text (`Instruct: ...\nQuery: ...`). `embed_documents` stays untouched since documents must not get the prefix.

The wrapping applies unconditionally because the configured `model_name` defaults to the `em_model` alias and cannot reliably identify E5 models (and it is unused entirely for the bundled local llama.cpp model).

## Verification

- No test suite in this repo, so I verified with a small script that monkeypatches `_get_embedding` and asserts `embed_query` receives the wrapped string while `embed_documents` (batched and unbatched) sends texts raw.
- `ruff check context_chat_backend/network_em.py` — passes
- `pyright context_chat_backend/network_em.py` — 0 errors (matches what CI's static-analysis workflow runs)

Fixes #331

Assisted-by: Claude Code