### PR TITLE
fix: do not log the database password on startup

### DIFF
--- a/dockerfile_scripts/pgsql/setup.sh
+++ b/dockerfile_scripts/pgsql/setup.sh
@@ -22,7 +22,9 @@ if [ -n "${EXTERNAL_DB}" ]; then
         exit 1
     fi
 
-    echo "Using EXTERNAL_DB, CCB_DB_URL is set to: $EXTERNAL_DB"
+    # the password must not reach the container log
+    redacted_db_url=$(printf '%s' "$EXTERNAL_DB" | sed -E 's#(://[^:/@]*):[^@]*@#\1:***@#')
+    echo "Using EXTERNAL_DB, CCB_DB_URL is set to: $redacted_db_url"
 
     if ! grep -q "^export EXTERNAL_DB=" /etc/environment; then
         echo "export EXTERNAL_DB=\"$EXTERNAL_DB\"" >> /etc/environment

--- a/dockerfile_scripts/pgsql/setup.sh
+++ b/dockerfile_scripts/pgsql/setup.sh
@@ -23,7 +23,7 @@ if [ -n "${EXTERNAL_DB}" ]; then
     fi
 
     # the password must not reach the container log
-    redacted_db_url=$(printf '%s' "$EXTERNAL_DB" | sed -E 's#(://[^:/@]*):[^@]*@#\1:***@#')
+    redacted_db_url=$(printf '%s' "$EXTERNAL_DB" | sed -E 's#(://[^:/@]*):[^/]*@#\1:***@#')
     echo "Using EXTERNAL_DB, CCB_DB_URL is set to: $redacted_db_url"
 
     if ! grep -q "^export EXTERNAL_DB=" /etc/environment; then


### PR DESCRIPTION
### The problem

`dockerfile_scripts/pgsql/setup.sh` prints `EXTERNAL_DB` verbatim on every start:

```bash
echo "Using EXTERNAL_DB, CCB_DB_URL is set to: $EXTERNAL_DB"
```

On a deployment that uses an external vector database, that means the database password lands in the container log:

```
Using EXTERNAL_DB, CCB_DB_URL is set to: postgresql+psycopg://ccb:s3cret@10.0.0.5:5433/ccb
```

`docker logs` shows it to anyone who can reach the daemon, and any log shipper carries it off the host. We noticed it while bringing up a four node deployment against an external Patroni cluster: the password we had just written to a `0600` env file was in `docker logs` a minute later.

### The change

Redact the credentials before printing. The scheme, user, host and database name — the parts that make the line useful for diagnosis — stay visible:

```
Using EXTERNAL_DB, CCB_DB_URL is set to: postgresql+psycopg://ccb:***@10.0.0.5:5433/ccb
```

### Testing

```
postgresql+psycopg://ccb:s3cret@172.17.0.1:5433/ccb   -> postgresql+psycopg://ccb:***@172.17.0.1:5433/ccb
postgresql+psycopg://ccb@host:5432/db                 -> unchanged (no password to hide)
postgresql+psycopg://user:p%40ss:word@h:5432/d        -> postgresql+psycopg://user:***@h:5432/d
```

`bash -n` on the script is clean.

Related: I sent the same class of fix to nextcloud/whiteboard in #1316, where the websocket server logged its Redis password the same way.
