### PR TITLE
fix(logging): let debug: true reach stderr, not only the log file

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,9 +49,15 @@ def _setup_log_levels(debug: bool):
 
 if __name__ == '__main__':
 	k8s_env = is_k8s_env()
-	logging_config = get_logging_config(LOGGER_K8S_CONFIG_NAME if k8s_env else LOGGER_CONFIG_NAME)
-	setup_logging(logging_config)
 	app_config: TConfig = app.extra['CONFIG']
+	logging_config = get_logging_config(LOGGER_K8S_CONFIG_NAME if k8s_env else LOGGER_CONFIG_NAME)
+	if app_config.debug:
+		# the file handler is already at DEBUG; without this the detail never reaches
+		# stderr, which is where a container deployment is read from
+		stderr_handler = logging_config.get('handlers', {}).get('stderr')
+		if stderr_handler is not None:
+			stderr_handler['level'] = 'DEBUG'
+	setup_logging(logging_config)
 	_setup_log_levels(app_config.debug)
 
 	# do forks from a clean process that doesn't have any threads or locks


### PR DESCRIPTION
Fixes #347

### Problem

`logger_config.yaml` pins the `stderr` handler at `WARNING`, so with `debug: true` the detail goes to `persistent_storage/logs/ccb.log` while `docker logs` stays nearly silent. `logger_config.k8s.yaml` already has stderr at `DEBUG`, so only the manual-install and Docker paths are affected.

Everything describing what indexing is doing is `INFO` or `DEBUG` — `Dispatching N file chunk(s)`, `Waiting for file chunk 1/8 future to complete`, `embed_sources finished for 4 source(s): 3 succeeded, 1 errored` with its per-source error dict. None of it surfaces. What does surface is the occasional `ERROR` traceback with no context around it, so from outside the container a healthy-but-slow run and a stuck one look identical.

### Change

When `debug` is on, lower the `stderr` handler along with the logger levels. Reading the app config a few lines earlier is what makes it possible to decide before `dictConfig` runs. The default stays `WARNING`, so nothing changes for anyone who has not asked for debug; the file handler is untouched.

Guarded with `.get()` so a config without a `stderr` handler — a custom one, say — still starts.

### Testing

On a four-node deployment with `debug: true`: before the change `docker logs` showed only startup lines and error tracebacks; after it, the batch dispatch and per-source results appear, which is what made diagnosing #345 possible without going into the container to read `ccb.log`.
