### PR TITLE
ci: fall back to github.token in the AI policy workflow

### DIFF
--- a/.github/workflows/ai-policy.yml
+++ b/.github/workflows/ai-policy.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Collect PR commit messages
         id: collect
         env:
-          GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT }}
+          GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT || github.token }}
           COMMITS_URL: ${{ github.event.pull_request.commits_url }}
         run: |
           set -euo pipefail
@@ -125,7 +125,7 @@ jobs:
       - name: Create 'AI assisted' label if absent
         if: steps.ai_trailers.outputs.ai_assisted == 'true' || steps.agent_signoff.outputs.agent_signoff == 'true' || steps.co_authored.outputs.co_authored == 'true'
         env:
-          GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT }}
+          GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT || github.token }}
         run: |
           gh api "repos/${{ github.repository }}/labels" \
             --method POST \
@@ -137,7 +137,7 @@ jobs:
       - name: Label PR as AI assisted
         if: steps.ai_trailers.outputs.ai_assisted == 'true' || steps.agent_signoff.outputs.agent_signoff == 'true' || steps.co_authored.outputs.co_authored == 'true'
         env:
-          GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT }}
+          GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT || github.token }}
         run: |
           gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" \
             --method POST \


### PR DESCRIPTION
### Problem

`check-ai-trailers` fails on every pull request from a fork, whatever the commits contain. The first step never gets as far as inspecting them:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
Process completed with exit code 4
```

Secrets are not exposed to `pull_request` runs from forks, so `secrets.COMMAND_BOT_PAT` is empty and `gh api` exits 4.

### Change

Fall back to `github.token`, which is what the organization template in [nextcloud/.github](https://github.com/nextcloud/.github/blob/master/.github/workflows/ai-policy.yml) already does:

```yaml
GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT || github.token }}
```

`nextcloud/spreed` already carries the updated version; this copy predates it. The workflow declares the permissions it needs (`contents: read`, `pull-requests: write`, `issues: write`), so the default token can read the commit list.

Noticed because it is the only red check on #343.
